### PR TITLE
Corrige alguns bugs de responsividade e refatora Page component

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+REACT_APP_BASE_URL=http://localhost:3000
+REACT_APP_ANALYTICS_URL=https://raw.githubusercontent.com/CodeForManaus/vacina-manaus-backend/master/analytics

--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -58,7 +58,7 @@ const Homepage = () => {
     <Page isLoading={isLoading}>
       <Paper className={primaryPaper}>
         <VaccinesAtMoment
-          vaccinesApplied={vaccine.vaccinationStatistics[0].vaccinated}
+          vaccinesApplied={vaccine?.vaccinationStatistics?.[0]?.vaccinated}
         />
       </Paper>
     </Page>

--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -10,7 +10,6 @@ import Copyright from './Copyright'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import Divider from '@material-ui/core/Divider'
 import Drawer from '@material-ui/core/Drawer'
-import Grid from '@material-ui/core/Grid'
 import IconButton from '@material-ui/core/IconButton'
 import List from '@material-ui/core/List'
 import MenuIcon from '@material-ui/icons/Menu'
@@ -22,9 +21,8 @@ import Snackbar from '@material-ui/core/Snackbar'
 import Toolbar from '@material-ui/core/Toolbar'
 import Typography from '@material-ui/core/Typography'
 import VaccinesAtMoment from './VaccinesAtMoment'
-import useMediaQuery from '@material-ui/core/useMediaQuery'
 import { VaccineContext } from '../contexts/VaccineContext'
-import { makeStyles, useTheme } from '@material-ui/core/styles'
+import { makeStyles } from '@material-ui/core/styles'
 
 const drawerWidth = 240
 
@@ -95,6 +93,7 @@ const useStyles = makeStyles((theme) => ({
   container: {
     paddingTop: theme.spacing(4),
     paddingBottom: theme.spacing(4),
+    minWidth: 320,
   },
   paper: {
     padding: theme.spacing(3),
@@ -107,9 +106,10 @@ const useStyles = makeStyles((theme) => ({
     background: 'linear-gradient(#1565c0, #9198e5)',
     color: 'white',
     boxShadow: 'rgba(0, 0, 0, 0.75) 0px 1px 10px 1px',
+    textAlign: 'center',
   },
   fixedHeight: {
-    height: 240,
+    minHeight: 240,
   },
 }))
 
@@ -123,8 +123,6 @@ const locale = 'pt-br'
 
 const Homepage = () => {
   const classes = useStyles()
-  const theme = useTheme()
-  const matches = useMediaQuery(theme.breakpoints.up('md'))
   const { vaccine } = useContext(VaccineContext)
   const [openMenu, setOpenMenu] = useState(false)
   const [isLoading, setLoading] = useState(true)
@@ -153,9 +151,8 @@ const Homepage = () => {
       vaccine.vaccinationStatistics.length > 0
     ) {
       fetchVaccineData(vaccine.vaccinationByDate, vaccine.vaccinationStatistics)
-      matches ? setOpenMenu(true) : setOpenMenu(false)
     }
-  }, [fetchVaccineData, vaccine, matches])
+  }, [fetchVaccineData, vaccine])
 
   return (
     <div>
@@ -201,7 +198,7 @@ const Homepage = () => {
             </Toolbar>
           </AppBar>
           <Drawer
-            variant='permanent'
+            anchor='left'
             classes={{
               paper: clsx(
                 classes.drawerPaper,
@@ -222,18 +219,12 @@ const Homepage = () => {
           </Drawer>
           <main className={classes.content}>
             <div className={classes.appBarSpacer} />
-            <Container maxWidth='xl' className={classes.container}>
-              <Grid container spacing={3}>
-                <Grid item xs={12} md={6} lg={6}>
-                  <Paper className={primaryPaper}>
-                    <VaccinesAtMoment
-                      vaccinesApplied={
-                        vaccine.vaccinationStatistics[0].vaccinated
-                      }
-                    />
-                  </Paper>
-                </Grid>
-              </Grid>
+            <Container maxWidth='sm' className={classes.container}>
+              <Paper className={primaryPaper}>
+                <VaccinesAtMoment
+                  vaccinesApplied={vaccine.vaccinationStatistics[0].vaccinated}
+                />
+              </Paper>
               <Box pt={4}>
                 <Copyright />
               </Box>

--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -154,99 +154,95 @@ const Homepage = () => {
     }
   }, [fetchVaccineData, vaccine])
 
+  if (isLoading) {
+    return <div> Carregando... </div>
+  }
+
   return (
-    <div>
-      {isLoading ? (
-        <div> Carregando... </div>
-      ) : (
-        <div className={classes.root}>
-          <CssBaseline />
-          <AppBar
-            position='absolute'
-            className={clsx(classes.appBar, openMenu && classes.appBarShift)}
+    <div className={classes.root}>
+      <CssBaseline />
+      <AppBar
+        position='absolute'
+        className={clsx(classes.appBar, openMenu && classes.appBarShift)}
+      >
+        <Toolbar className={classes.toolbar}>
+          <IconButton
+            edge='start'
+            color='inherit'
+            aria-label='open drawer'
+            onClick={handleMenu}
+            className={clsx(
+              classes.menuButton,
+              openMenu && classes.menuButtonHidden
+            )}
           >
-            <Toolbar className={classes.toolbar}>
-              <IconButton
-                edge='start'
-                color='inherit'
-                aria-label='open drawer'
-                onClick={handleMenu}
-                className={clsx(
-                  classes.menuButton,
-                  openMenu && classes.menuButtonHidden
-                )}
-              >
-                <MenuIcon />
-              </IconButton>
-              <Typography
-                component='h1'
-                variant='h6'
-                color='inherit'
-                noWrap
-                className={classes.title}
-              >
-                #VacinaManaus
-              </Typography>
-              <IconButton
-                onClick={() => setNotification({ badge: 0, alert: true })}
-                color='inherit'
-              >
-                <Badge badgeContent={notification.badge} color='secondary'>
-                  <NotificationsIcon />
-                </Badge>
-              </IconButton>
-            </Toolbar>
-          </AppBar>
-          <Drawer
-            anchor='left'
-            classes={{
-              paper: clsx(
-                classes.drawerPaper,
-                !openMenu && classes.drawerPaperClose
-              ),
-            }}
-            open={openMenu}
+            <MenuIcon />
+          </IconButton>
+          <Typography
+            component='h1'
+            variant='h6'
+            color='inherit'
+            noWrap
+            className={classes.title}
           >
-            <div className={classes.toolbarIcon}>
-              <IconButton onClick={handleMenu}>
-                <ChevronLeftIcon />
-              </IconButton>
-            </div>
-            <Divider />
-            <List>
-              <SidebarItems />
-            </List>
-          </Drawer>
-          <main className={classes.content}>
-            <div className={classes.appBarSpacer} />
-            <Container maxWidth='sm' className={classes.container}>
-              <Paper className={primaryPaper}>
-                <VaccinesAtMoment
-                  vaccinesApplied={vaccine.vaccinationStatistics[0].vaccinated}
-                />
-              </Paper>
-              <Box pt={4}>
-                <Copyright />
-              </Box>
-            </Container>
-            <Snackbar
-              open={notification.alert}
-              autoHideDuration={5000}
-              onClose={() => setNotification({ ...notification, alert: false })}
-            >
-              <MuiAlert
-                severity='success'
-                onClose={() =>
-                  setNotification({ ...notification, alert: false })
-                }
-              >
-                Última atualização dos dados:{' '}
-                {new Date().toLocaleDateString(locale, option)}
-              </MuiAlert>
-            </Snackbar>
-          </main>
+            #VacinaManaus
+          </Typography>
+          <IconButton
+            onClick={() => setNotification({ badge: 0, alert: true })}
+            color='inherit'
+          >
+            <Badge badgeContent={notification.badge} color='secondary'>
+              <NotificationsIcon />
+            </Badge>
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <Drawer
+        anchor='left'
+        classes={{
+          paper: clsx(
+            classes.drawerPaper,
+            !openMenu && classes.drawerPaperClose
+          ),
+        }}
+        open={openMenu}
+      >
+        <div className={classes.toolbarIcon}>
+          <IconButton onClick={handleMenu}>
+            <ChevronLeftIcon />
+          </IconButton>
         </div>
-      )}
+        <Divider />
+        <List>
+          <SidebarItems />
+        </List>
+      </Drawer>
+      <main className={classes.content}>
+        <div className={classes.appBarSpacer} />
+        <Container maxWidth='sm' className={classes.container}>
+          <Paper className={primaryPaper}>
+            <VaccinesAtMoment
+              vaccinesApplied={vaccine.vaccinationStatistics[0].vaccinated}
+            />
+          </Paper>
+          <Box pt={4}>
+            <Copyright />
+          </Box>
+        </Container>
+        <Snackbar
+          open={notification.alert}
+          autoHideDuration={5000}
+          onClose={() => setNotification({ ...notification, alert: false })}
+        >
+          <MuiAlert
+            severity='success'
+            onClose={() => setNotification({ ...notification, alert: false })}
+          >
+            Última atualização dos dados:{' '}
+            {new Date().toLocaleDateString(locale, option)}
+          </MuiAlert>
+        </Snackbar>
+      </main>
     </div>
   )
 }

--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -1,100 +1,14 @@
 import React, { useCallback, useEffect, useState, useContext } from 'react'
 import clsx from 'clsx'
 
-import AppBar from '@material-ui/core/AppBar'
-import Badge from '@material-ui/core/Badge'
-import Box from '@material-ui/core/Box'
-import ChevronLeftIcon from '@material-ui/icons/ChevronLeft'
-import Container from '@material-ui/core/Container'
-import Copyright from './Copyright'
-import CssBaseline from '@material-ui/core/CssBaseline'
-import Divider from '@material-ui/core/Divider'
-import Drawer from '@material-ui/core/Drawer'
-import IconButton from '@material-ui/core/IconButton'
-import List from '@material-ui/core/List'
-import MenuIcon from '@material-ui/icons/Menu'
-import MuiAlert from '@material-ui/lab/Alert'
-import NotificationsIcon from '@material-ui/icons/Notifications'
 import Paper from '@material-ui/core/Paper'
-import SidebarItems from './SidebarItems'
-import Snackbar from '@material-ui/core/Snackbar'
-import Toolbar from '@material-ui/core/Toolbar'
-import Typography from '@material-ui/core/Typography'
 import VaccinesAtMoment from './VaccinesAtMoment'
 import { VaccineContext } from '../contexts/VaccineContext'
 import { makeStyles } from '@material-ui/core/styles'
 
-const drawerWidth = 240
+import Page from './Page'
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-  },
-  toolbar: {
-    paddingRight: 24, // keep right padding when drawer closed
-  },
-  toolbarIcon: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: '0 8px',
-    ...theme.mixins.toolbar,
-  },
-  appBar: {
-    zIndex: theme.zIndex.drawer + 1,
-    transition: theme.transitions.create(['width', 'margin'], {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-  },
-  appBarShift: {
-    marginLeft: drawerWidth,
-    width: `calc(100% - ${drawerWidth}px)`,
-    transition: theme.transitions.create(['width', 'margin'], {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  },
-  menuButton: {
-    marginRight: 36,
-  },
-  menuButtonHidden: {
-    display: 'none',
-  },
-  title: {
-    flexGrow: 1,
-  },
-  drawerPaper: {
-    position: 'relative',
-    whiteSpace: 'nowrap',
-    width: drawerWidth,
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  },
-  drawerPaperClose: {
-    overflowX: 'hidden',
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    width: theme.spacing(7),
-    [theme.breakpoints.up('sm')]: {
-      width: theme.spacing(9),
-    },
-  },
-  appBarSpacer: theme.mixins.toolbar,
-  content: {
-    flexGrow: 1,
-    height: '100vh',
-    overflow: 'auto',
-  },
-  container: {
-    paddingTop: theme.spacing(4),
-    paddingBottom: theme.spacing(4),
-    minWidth: 320,
-  },
   paper: {
     padding: theme.spacing(3),
     margin: 12,
@@ -113,20 +27,10 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-const option = {
-  year: 'numeric',
-  month: 'long' || 'short' || 'numeric',
-  weekday: 'long' || 'short',
-  day: 'numeric',
-}
-const locale = 'pt-br'
-
 const Homepage = () => {
   const classes = useStyles()
   const { vaccine } = useContext(VaccineContext)
-  const [openMenu, setOpenMenu] = useState(false)
   const [isLoading, setLoading] = useState(true)
-  const [notification, setNotification] = useState({ badge: 1, alert: false })
   const primaryPaper = clsx(
     classes.paper,
     classes.cardPrimary,
@@ -141,10 +45,6 @@ const Homepage = () => {
     setLoading(false)
   }, [])
 
-  const handleMenu = () => {
-    setOpenMenu(!openMenu)
-  }
-
   useEffect(() => {
     if (
       vaccine.vaccinationByDate.length > 0 &&
@@ -154,96 +54,14 @@ const Homepage = () => {
     }
   }, [fetchVaccineData, vaccine])
 
-  if (isLoading) {
-    return <div> Carregando... </div>
-  }
-
   return (
-    <div className={classes.root}>
-      <CssBaseline />
-      <AppBar
-        position='absolute'
-        className={clsx(classes.appBar, openMenu && classes.appBarShift)}
-      >
-        <Toolbar className={classes.toolbar}>
-          <IconButton
-            edge='start'
-            color='inherit'
-            aria-label='open drawer'
-            onClick={handleMenu}
-            className={clsx(
-              classes.menuButton,
-              openMenu && classes.menuButtonHidden
-            )}
-          >
-            <MenuIcon />
-          </IconButton>
-          <Typography
-            component='h1'
-            variant='h6'
-            color='inherit'
-            noWrap
-            className={classes.title}
-          >
-            #VacinaManaus
-          </Typography>
-          <IconButton
-            onClick={() => setNotification({ badge: 0, alert: true })}
-            color='inherit'
-          >
-            <Badge badgeContent={notification.badge} color='secondary'>
-              <NotificationsIcon />
-            </Badge>
-          </IconButton>
-        </Toolbar>
-      </AppBar>
-      <Drawer
-        anchor='left'
-        classes={{
-          paper: clsx(
-            classes.drawerPaper,
-            !openMenu && classes.drawerPaperClose
-          ),
-        }}
-        open={openMenu}
-      >
-        <div className={classes.toolbarIcon}>
-          <IconButton onClick={handleMenu}>
-            <ChevronLeftIcon />
-          </IconButton>
-        </div>
-        <Divider />
-        <List>
-          <SidebarItems />
-        </List>
-      </Drawer>
-      <main className={classes.content}>
-        <div className={classes.appBarSpacer} />
-        <Container maxWidth='sm' className={classes.container}>
-          <Paper className={primaryPaper}>
-            <VaccinesAtMoment
-              vaccinesApplied={vaccine.vaccinationStatistics[0].vaccinated}
-            />
-          </Paper>
-          <Box pt={4}>
-            <Copyright />
-          </Box>
-        </Container>
-        <Snackbar
-          open={notification.alert}
-          autoHideDuration={5000}
-          onClose={() => setNotification({ ...notification, alert: false })}
-        >
-          <MuiAlert
-            severity='success'
-            onClose={() => setNotification({ ...notification, alert: false })}
-          >
-            Última atualização dos dados:{' '}
-            {new Date().toLocaleDateString(locale, option)}
-          </MuiAlert>
-        </Snackbar>
-      </main>
-    </div>
+    <Page isLoading={isLoading}>
+      <Paper className={primaryPaper}>
+        <VaccinesAtMoment
+          vaccinesApplied={vaccine.vaccinationStatistics[0].vaccinated}
+        />
+      </Paper>
+    </Page>
   )
 }
 

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,0 +1,209 @@
+import React, { useState } from 'react'
+import clsx from 'clsx'
+import PropTypes from 'prop-types'
+
+import AppBar from '@material-ui/core/AppBar'
+import Badge from '@material-ui/core/Badge'
+import Box from '@material-ui/core/Box'
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft'
+import Container from '@material-ui/core/Container'
+import Copyright from './Copyright'
+import CssBaseline from '@material-ui/core/CssBaseline'
+import Divider from '@material-ui/core/Divider'
+import Drawer from '@material-ui/core/Drawer'
+import IconButton from '@material-ui/core/IconButton'
+import List from '@material-ui/core/List'
+import MenuIcon from '@material-ui/icons/Menu'
+import MuiAlert from '@material-ui/lab/Alert'
+import NotificationsIcon from '@material-ui/icons/Notifications'
+import SidebarItems from './SidebarItems'
+import Snackbar from '@material-ui/core/Snackbar'
+import Toolbar from '@material-ui/core/Toolbar'
+import Typography from '@material-ui/core/Typography'
+import { makeStyles } from '@material-ui/core/styles'
+
+const drawerWidth = 240
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+  },
+  toolbar: {
+    paddingRight: 24, // keep right padding when drawer closed
+  },
+  toolbarIcon: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    padding: '0 8px',
+    ...theme.mixins.toolbar,
+  },
+  appBar: {
+    zIndex: theme.zIndex.drawer + 1,
+    transition: theme.transitions.create(['width', 'margin'], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+  },
+  appBarShift: {
+    marginLeft: drawerWidth,
+    width: `calc(100% - ${drawerWidth}px)`,
+    transition: theme.transitions.create(['width', 'margin'], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+  menuButton: {
+    marginRight: 36,
+  },
+  menuButtonHidden: {
+    display: 'none',
+  },
+  title: {
+    flexGrow: 1,
+  },
+  drawerPaper: {
+    position: 'relative',
+    whiteSpace: 'nowrap',
+    width: drawerWidth,
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+  drawerPaperClose: {
+    overflowX: 'hidden',
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+    width: theme.spacing(7),
+    [theme.breakpoints.up('sm')]: {
+      width: theme.spacing(9),
+    },
+  },
+  appBarSpacer: theme.mixins.toolbar,
+  content: {
+    flexGrow: 1,
+    height: '100vh',
+    overflow: 'auto',
+  },
+  container: {
+    paddingTop: theme.spacing(4),
+    paddingBottom: theme.spacing(4),
+    minWidth: 320,
+  },
+}))
+
+const option = {
+  year: 'numeric',
+  month: 'long' || 'short' || 'numeric',
+  weekday: 'long' || 'short',
+  day: 'numeric',
+}
+const locale = 'pt-br'
+
+const Page = ({ children, isLoading = false }) => {
+  const classes = useStyles()
+  const [openMenu, setOpenMenu] = useState(false)
+  const [notification, setNotification] = useState({ badge: 1, alert: false })
+
+  const handleMenu = () => {
+    setOpenMenu(!openMenu)
+  }
+
+  if (isLoading) {
+    return <div> Carregando... </div>
+  }
+
+  return (
+    <div className={classes.root}>
+      <CssBaseline />
+      <AppBar
+        position='absolute'
+        className={clsx(classes.appBar, openMenu && classes.appBarShift)}
+      >
+        <Toolbar className={classes.toolbar}>
+          <IconButton
+            edge='start'
+            color='inherit'
+            aria-label='open drawer'
+            onClick={handleMenu}
+            className={clsx(
+              classes.menuButton,
+              openMenu && classes.menuButtonHidden
+            )}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography
+            component='h1'
+            variant='h6'
+            color='inherit'
+            noWrap
+            className={classes.title}
+          >
+            #VacinaManaus
+          </Typography>
+          <IconButton
+            onClick={() => setNotification({ badge: 0, alert: true })}
+            color='inherit'
+          >
+            <Badge badgeContent={notification.badge} color='secondary'>
+              <NotificationsIcon />
+            </Badge>
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <Drawer
+        anchor='left'
+        classes={{
+          paper: clsx(
+            classes.drawerPaper,
+            !openMenu && classes.drawerPaperClose
+          ),
+        }}
+        open={openMenu}
+      >
+        <div className={classes.toolbarIcon}>
+          <IconButton onClick={handleMenu}>
+            <ChevronLeftIcon />
+          </IconButton>
+        </div>
+        <Divider />
+        <List>
+          <SidebarItems />
+        </List>
+      </Drawer>
+      <main className={classes.content}>
+        <div className={classes.appBarSpacer} />
+        <Container maxWidth='sm' className={classes.container}>
+          {children}
+        </Container>
+        <Box pt={4}>
+          <Copyright />
+        </Box>
+        <Snackbar
+          open={notification.alert}
+          autoHideDuration={5000}
+          onClose={() => setNotification({ ...notification, alert: false })}
+        >
+          <MuiAlert
+            severity='success'
+            onClose={() => setNotification({ ...notification, alert: false })}
+          >
+            Última atualização dos dados:{' '}
+            {new Date().toLocaleDateString(locale, option)}
+          </MuiAlert>
+        </Snackbar>
+      </main>
+    </div>
+  )
+}
+
+Page.propTypes = {
+  children: PropTypes.Node,
+  isLoading: PropTypes.bool,
+}
+
+export default Page


### PR DESCRIPTION
### Done
- Define tamanho minimo para alguns componentes (evitar que componentes sejam esticados além da conta)
- Centraliza elementos para melhor visualização em todas as telas
- Adiciona .env.development para facilitar configuração de ambiente para novos developers
- Refatora Homepage para extrair essencia da Page em novo componente (preparação pra página de analytics)
- Alterado Drawer para ser temporário, sobrepondo o conteúdo da tela principal, para evitar comportamentos estranho em telas menores (olhar Issues abaixo)

### Proofs
- Home em tela grande
![home-dev-1](https://user-images.githubusercontent.com/2866548/107132513-10324a80-68b6-11eb-8f4c-d6e0678c42e7.png)

- Home em tela grande (com drawer aberto)
![lg-open-drawer](https://user-images.githubusercontent.com/2866548/107132524-22ac8400-68b6-11eb-8aa6-e5b7bbccb3b9.png)

- Home em tela pequena
![sm-home-dev-1](https://user-images.githubusercontent.com/2866548/107132529-33f59080-68b6-11eb-834a-23e764063777.png)

- Home em tela pequena (com drawer aberto)
![sm-open-drawer](https://user-images.githubusercontent.com/2866548/107132530-3526bd80-68b6-11eb-899a-1692646a16d5.png)

